### PR TITLE
feat: passphrase default options

### DIFF
--- a/diceware.py
+++ b/diceware.py
@@ -1,10 +1,17 @@
+PASSPHRASE_DEFAULTS: dict = {
+    "number_of_words": 6,
+    "min_words": 1,
+    "delimiter": "",
+}
+
+
 class Passphrase:
     def __init__(self, number_of_words: int, delimiter: str) -> None:
         self.number_of_words: int = number_of_words
         self.delimiter: str = delimiter
 
 
-def is_valid_int(user_input: str, min_value: int = 1) -> bool:
+def is_valid_int(user_input: str, min_value) -> bool:
     result: bool = False
     try:
         value = int(user_input)
@@ -18,10 +25,15 @@ def is_valid_int(user_input: str, min_value: int = 1) -> bool:
     return result
 
 
-def read_int(prompt: str) -> int:
+def read_number_of_words(prompt: str):
     while True:
         user_input = input(prompt)
-        if is_valid_int(user_input, min_value=1):
+        if user_input == "":
+            return PASSPHRASE_DEFAULTS["number_of_words"]
+        if is_valid_int(
+            user_input,
+            min_value=PASSPHRASE_DEFAULTS["min_words"],
+        ):
             return int(user_input)
 
 
@@ -31,8 +43,12 @@ def read_delimiter(prompt: str) -> str:
 
 
 def main() -> None:
-    number_of_words = read_int("Number of words: ")
-    delimiter = read_delimiter("Delimiter: ")
+    number_of_words = read_number_of_words(
+        f"Number of words (default={PASSPHRASE_DEFAULTS['number_of_words']}): "
+    )
+    delimiter = read_delimiter(
+        f"Delimiter (default=\"{PASSPHRASE_DEFAULTS['delimiter']}\"): "
+    )
     passphrase = Passphrase(number_of_words, delimiter)
 
 

--- a/test_diceware.py
+++ b/test_diceware.py
@@ -1,6 +1,6 @@
 from pytest import MonkeyPatch
 
-from diceware import is_valid_int, read_delimiter, read_int
+from diceware import is_valid_int, read_delimiter, read_number_of_words
 
 
 def test_is_valid_int_when_input_is_valid():
@@ -25,14 +25,21 @@ def test_is_valid_int_when_input_is_too_low(capfd):
     assert "The minimum value is 3" in out
 
 
-def test_read_int_valid_input(monkeypatch: MonkeyPatch):
-    valid_input = "6"
+def test_read_number_of_words_valid_input(monkeypatch: MonkeyPatch):
+    valid_input = "7"
     monkeypatch.setattr("builtins.input", lambda _: valid_input)
-    result = read_int("Enter a number: ")
+    result = read_number_of_words("Number of words: ")
+    assert result == 7
+
+
+def test_read_number_of_words_empty_input_defaults(monkeypatch: MonkeyPatch):
+    empty_input = ""
+    monkeypatch.setattr("builtins.input", lambda _: empty_input)
+    result = read_number_of_words("Number of words: ")
     assert result == 6
 
 
-def test_read_delimiter(monkeypatch: MonkeyPatch):
+def test_read_delimiter_with_input(monkeypatch: MonkeyPatch):
     input = "_"
     monkeypatch.setattr("builtins.input", lambda _: input)
     result = read_delimiter("Delimiter: ")


### PR DESCRIPTION
### Description

Feature for default options for passphrase (number of words, delimiter...).

Unfortunately this meant removing some type hints as mypy does not like the dictionary used for default options. There might be a way around this?

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
