### PR TITLE
feat: cli quiet option

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 from py_diceware.cli import main
+from py_diceware.config import PassphraseDefaults
 
 """These cli tests rely on:
     - the passphrase being the final line in the output
@@ -77,3 +78,23 @@ def test_cli_no_delimiter():
     passphrase_output = result.output.splitlines()[PASSPHRASE_OUTPUT_LINE]
     assert result.exit_code == 0
     assert len(passphrase_output.split()) == 1
+
+
+def test_cli_quiet_mode():
+    runner = CliRunner()
+    result = runner.invoke(main, "--words 10 --delimiter '_' --quiet")
+    full_output = result.output.splitlines()
+    passphrase_words = full_output[0].split("_")
+    assert result.exit_code == 0
+    assert len(full_output) == 1
+    assert len(passphrase_words) == 10
+
+
+def test_cli_quiet_mode_skips_number_words_prompt():
+    runner = CliRunner()
+    result = runner.invoke(main, "--delimiter '_' --quiet")
+    full_output = result.output.splitlines()
+    passphrase_words = full_output[0].split("_")
+    assert result.exit_code == 0
+    assert len(full_output) == 1
+    assert len(passphrase_words) == PassphraseDefaults.number_of_words


### PR DESCRIPTION
### Description

Feature for quiet mode option which will only output the passphrase and silence prompts and other output.

Example usage:

```sh 
$ py-diceware --words 8 --quiet
ArcherYuckCancerPartyFeudAiBooze53rd
```

### Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
